### PR TITLE
Init filters to proper object type

### DIFF
--- a/nerdlets/nr1-open-boards-nerdlet/components/nerdletstate-handler/index.js
+++ b/nerdlets/nr1-open-boards-nerdlet/components/nerdletstate-handler/index.js
@@ -45,7 +45,7 @@ export default class NerdletStateHandler extends React.PureComponent {
 
         stateUpdate.storageLocation = selectedStorageLocation;
         stateUpdate.selectedBoard = selectedBoard;
-        stateUpdate.filters = filters || [];
+        stateUpdate.filters = filters || {};
 
         updateDataStateContext({ urlStateChecked: true, ...stateUpdate });
       }


### PR DESCRIPTION
@Kav91 found it! Filter linking works now.